### PR TITLE
Ignore new AWS reserved params on copy_task_definition

### DIFF
--- a/ecstools/resources/task_definition.py
+++ b/ecstools/resources/task_definition.py
@@ -87,6 +87,8 @@ class TaskDefinition(object):
         aws_reserved_params = ['status',
                                'compatibilities',
                                'taskDefinitionArn',
+                               'registeredAt',
+                               'registeredBy',
                                'revision',
                                'requiresAttributes'
                                ]


### PR DESCRIPTION
Ignore `registeredAt` and `registeredBy` AWS reserved params on `copy_task_definition`